### PR TITLE
Generando jornadas

### DIFF
--- a/Lecoib (Pks AI).sql
+++ b/Lecoib (Pks AI).sql
@@ -230,15 +230,15 @@ INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `e
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Romero', 'Veronica', '22222221', '20120101', 'none@none,com', '1', '1', '1');
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Gonzalez', 'Juan', '44444445', '20140101', 'none@none.com', '1', '2', '2');
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Martinez', 'Mariano', '11111118', '20150101', 'none@none.com', '1', '3', '3');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sabina', 'Miriam', '12322223', '20140101', 'none@none.com', '2', '4', '1');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Zulani', 'Jose', '19322223', '20140101', 'none@none.com', '2', '4', '1');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Miliani', 'Roberto', '12722223', '20140101', 'none@none.com', '2', '5', '2');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Hilkins', 'Martin', '12762223', '20140101', 'none@none.com', '2', '5', '2');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Gonzalez', 'Carlos', '12322993', '20140101', 'none@none.com', '2', '6', '3');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sullvert', 'Patricio', '12322923', '20140101', 'none@none.com', '2', '6', '3');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Danilo', 'Esteban', '12331223', '20140101', 'none@none.com', '1', '4', '1');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Stein', 'Estella', '12321123', '20140101', 'none@none.com', '1', '5', '2');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Maverick', 'Juan', '12322529', '20140101', 'none@none.com', '1', '6', '3');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Sabina', 'Miriam', '12322223', '20140101', 'none@none.com', '2', '4', '1');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Zulani', 'Jose', '19322223', '20140101', 'none@none.com', '2', '4', '1');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Miliani', 'Roberto', '12722223', '20140101', 'none@none.com', '2', '5', '2');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Hilkins', 'Martin', '12762223', '20140101', 'none@none.com', '2', '5', '2');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Gonzalez', 'Carlos', '12322993', '20140101', 'none@none.com', '2', '6', '3');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Sullvert', 'Patricio', '12322923', '20140101', 'none@none.com', '2', '6', '3');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Danilo', 'Esteban', '12331223', '20140101', 'none@none.com', '1', '4', '1');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Stein', 'Estella', '12321123', '20140101', 'none@none.com', '1', '5', '2');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Maverick', 'Juan', '12322529', '20140101', 'none@none.com', '1', '6', '3');
 
 -- -----------------------------------------------------
 -- Table `lecoib`.`Usuario` Solo 1 como supervisor.

--- a/Lecoib (Pks AI).sql
+++ b/Lecoib (Pks AI).sql
@@ -230,15 +230,15 @@ INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `e
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Romero', 'Veronica', '22222221', '20120101', 'none@none,com', '1', '1', '1');
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Gonzalez', 'Juan', '44444445', '20140101', 'none@none.com', '1', '2', '2');
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Martinez', 'Mariano', '11111118', '20150101', 'none@none.com', '1', '3', '3');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sabina', 'Miriam', '12322223', '20140101', 'none@none.com', '2', '4');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Zulani', 'Jose', '19322223', '20140101', 'none@none.com', '2', '4');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Miliani', 'Roberto', '12722223', '20140101', 'none@none.com', '2', '5');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Hilkins', 'Martin', '12762223', '20140101', 'none@none.com', '2', '5');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Gonzalez', 'Carlos', '12322993', '20140101', 'none@none.com', '2', '6');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sullvert', 'Patricio', '12322923', '20140101', 'none@none.com', '2', '6');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Danilo', 'Esteban', '12331223', '20140101', 'none@none.com', '1', '4');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Stein', 'Estella', '12321123', '20140101', 'none@none.com', '1', '5');
-INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Maverick', 'Juan', '12322529', '20140101', 'none@none.com', '1', '6');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sabina', 'Miriam', '12322223', '20140101', 'none@none.com', '2', '4', '1');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Zulani', 'Jose', '19322223', '20140101', 'none@none.com', '2', '4', '1');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Miliani', 'Roberto', '12722223', '20140101', 'none@none.com', '2', '5', '2');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Hilkins', 'Martin', '12762223', '20140101', 'none@none.com', '2', '5', '2');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Gonzalez', 'Carlos', '12322993', '20140101', 'none@none.com', '2', '6', '3');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sullvert', 'Patricio', '12322923', '20140101', 'none@none.com', '2', '6', '3');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Danilo', 'Esteban', '12331223', '20140101', 'none@none.com', '1', '4', '1');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Stein', 'Estella', '12321123', '20140101', 'none@none.com', '1', '5', '2');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Maverick', 'Juan', '12322529', '20140101', 'none@none.com', '1', '6', '3');
 
 -- -----------------------------------------------------
 -- Table `lecoib`.`Usuario` Solo 1 como supervisor.

--- a/Lecoib (Pks AI).sql
+++ b/Lecoib (Pks AI).sql
@@ -209,6 +209,9 @@ INSERT INTO `lecoib`.`Categoria` (`nombreCat`, `sueldoBasico`) VALUES ('Agente',
 INSERT INTO `lecoib`.`GrupoTrabajo` (`nombreGrupo`) VALUES ('PrimerGrupo');
 INSERT INTO `lecoib`.`GrupoTrabajo` (`nombreGrupo`) VALUES ('SegundoGrupo');
 INSERT INTO `lecoib`.`GrupoTrabajo` (`nombreGrupo`) VALUES ('TercerGrupo');
+INSERT INTO `lecoib`.`GrupoTrabajo` (`nombreGrupo`) VALUES ('CuartoGrupo');
+INSERT INTO `lecoib`.`GrupoTrabajo` (`nombreGrupo`) VALUES ('QuintoGrupo');
+INSERT INTO `lecoib`.`GrupoTrabajo` (`nombreGrupo`) VALUES ('SextoGrupo');
 -- -----------------------------------------------------
 -- Table `lecoib`.`Turno`. MAñana, TArde y NOche
 -- -----------------------------------------------------
@@ -227,6 +230,16 @@ INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `e
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Romero', 'Veronica', '22222221', '20120101', 'none@none,com', '1', '1', '1');
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Gonzalez', 'Juan', '44444445', '20140101', 'none@none.com', '1', '2', '2');
 INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`, `idTurno`) VALUES ('Martinez', 'Mariano', '11111118', '20150101', 'none@none.com', '1', '3', '3');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sabina', 'Miriam', '12322223', '20140101', 'none@none.com', '2', '4');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Zulani', 'Jose', '19322223', '20140101', 'none@none.com', '2', '4');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Miliani', 'Roberto', '12722223', '20140101', 'none@none.com', '2', '5');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Hilkins', 'Martin', '12762223', '20140101', 'none@none.com', '2', '5');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Gonzalez', 'Carlos', '12322993', '20140101', 'none@none.com', '2', '6');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Sullvert', 'Patricio', '12322923', '20140101', 'none@none.com', '2', '6');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Danilo', 'Esteban', '12331223', '20140101', 'none@none.com', '1', '4');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Stein', 'Estella', '12321123', '20140101', 'none@none.com', '1', '5');
+INSERT INTO `lecoib`.`Empleado` (`apellido`, `nombre`, `dni`, `fechaIngreso`, `email`, `idCategoria`, `idGrupo`) VALUES ('Maverick', 'Juan', '12322529', '20140101', 'none@none.com', '1', '6');
+
 -- -----------------------------------------------------
 -- Table `lecoib`.`Usuario` Solo 1 como supervisor.
 -- -----------------------------------------------------

--- a/src/negocio/JornadaABM.java
+++ b/src/negocio/JornadaABM.java
@@ -77,28 +77,33 @@ public class JornadaABM
 		String turno;
 		int grupo;
 		EmpleadoABM eABM = new EmpleadoABM();
-		List<Empleado> lstEmpleados = eABM.traerEmpleado();		
-		List<Empleado> lstGrupo = new ArrayList<Empleado>();
+		List<Empleado> lstEmpleados = eABM.traerEmpleado();
+		List<Empleado> lstEmpleadosAux = lstEmpleados;
 
 		for(Empleado e : lstEmpleados)
 		{
-			//Primer empleado pivote
+			//empleado pivote
+			List<Empleado> lstGrupo = new ArrayList<Empleado>();
 			turno = e.getTurno().getTurno();
 			grupo = e.getGrupoTrabajo().getidGrupo();
-			lstGrupo.add(e);
-			lstEmpleados.remove(e);
-			for(Empleado e1 : lstEmpleados)
+			for(Empleado e1 : lstEmpleadosAux)
 			{
 				if (e1.getGrupoTrabajo().getidGrupo() == grupo)
 				{
 					lstGrupo.add(e1);
-					lstEmpleados.remove(e1);
 				}
-				
 			}
 			//Aca deberia tener un grupo completo para asignar jornadas
-			asignaJornada(lstGrupo, Funciones.traerMes(fecha), Funciones.traerAnio(fecha));
+			if (!(lstGrupo == null))
+			{
+				for(Empleado e2 : lstGrupo)
+				{
+					lstEmpleadosAux.remove(e2);
+				}
+				asignaJornada(lstGrupo, Funciones.traerMes(fecha), Funciones.traerAnio(fecha));
+			}
 		}
+		
 					
 	}
 	

--- a/src/negocio/JornadaABM.java
+++ b/src/negocio/JornadaABM.java
@@ -69,11 +69,93 @@ public class JornadaABM
 			throw new Exception ("Error: La fecha ingresada es incorrecta");
 		}
 	}
+
+	public void generarJornadasMes()throws Exception 
+	{
+		//Alta automatica de jornadas
+		GregorianCalendar fecha = new GregorianCalendar();
+		String turno;
+		int grupo;
+		EmpleadoABM eABM = new EmpleadoABM();
+		List<Empleado> lstEmpleados = eABM.traerEmpleado();		
+		List<Empleado> lstGrupo = new ArrayList<Empleado>();
+
+		for(Empleado e : lstEmpleados)
+		{
+			//Primer empleado pivote
+			turno = e.getTurno().getTurno();
+			grupo = e.getGrupoTrabajo().getidGrupo();
+			lstGrupo.add(e);
+			lstEmpleados.remove(e);
+			for(Empleado e1 : lstEmpleados)
+			{
+				if (e1.getGrupoTrabajo().getidGrupo() == grupo)
+				{
+					lstGrupo.add(e1);
+					lstEmpleados.remove(e1);
+				}
+				
+			}
+			//Aca deberia tener un grupo completo para asignar jornadas
+			asignaJornada(lstGrupo, Funciones.traerMes(fecha), Funciones.traerAnio(fecha));
+		}
+					
+	}
 	
-	public void asignaJornada(List<Empleado> lstEmpleado, int mes, int anio){
-		for(Empleado e : lstEmpleado){
-			int checkFranco = 0;
-			for(int i=1; i<=Funciones.traerCantDiasDeUnMes(mes, anio); i++){
+	
+	public void asignaJornada(List<Empleado> lstEmpleado, int mes, int anio) throws Exception{
+		//Aprovecho el método pero debo hacerle modificaciones
+		int mesPasado = mes;
+		int anioPasado = anio;
+		int checkFranco = 0;
+		int diaComienzo = 1;
+		
+		//Evaluo si existe jornada mes anterior o es primera
+		if (mes == 1)//Prueba obligatoria para que no pinche en Enero
+		{
+			anioPasado = anio-1;
+		}else{mesPasado = mesPasado -1;}
+		
+		GregorianCalendar fechaMesPasado = new GregorianCalendar(anioPasado, mesPasado, Funciones.traerCantDiasDeUnMes(mesPasado, anioPasado));
+		if (evaluarMesAnterior(fechaMesPasado) == true)
+		{
+			//Aca tiene que hacer todo el lio para continuar el mes anterior del grupo
+			
+		}
+		else //Debe determinar donde comenzar (Si hay otro grupo asignado buscar Franco)
+		{
+			boolean listo = false;
+			while (listo == false)
+			{
+				GregorianCalendar fechaJornadaEvaluar = new GregorianCalendar(anio, mes, diaComienzo);
+				List<Jornada> lstjornadasEvaluar = traerJornadasPorFecha(fechaJornadaEvaluar);
+				if (lstjornadasEvaluar != null)
+				{
+					int z = 1;
+					boolean pasar = false;
+					while ( z <= lstjornadasEvaluar.size() && pasar == false)
+					{
+						if ( lstjornadasEvaluar.get(z).getTurno() == lstEmpleado.get(1).getTurno())
+						{
+							diaComienzo++;
+							pasar = true;
+						}
+					}
+					if (pasar == false)
+					{
+						listo =true;
+					}
+				}else{listo=true;}
+				if (diaComienzo >= Funciones.traerCantDiasDeUnMes(mes, anio))
+				{
+					listo=true;
+					diaComienzo=1;
+				}
+			}
+		}
+		for(Empleado e : lstEmpleado)
+		{
+			for(int i=diaComienzo; i<=Funciones.traerCantDiasDeUnMes(mes, anio); i++){
 				//asigno jornada
 				GregorianCalendar fechaJornada = new GregorianCalendar(anio, mes, i);
 				Jornada jornada = new Jornada(fechaJornada, e, e.getTurno());
@@ -85,6 +167,16 @@ public class JornadaABM
 				}
 			}
 		}
+	}
+	
+	private boolean evaluarMesAnterior(GregorianCalendar fechaMesAnterior) throws Exception
+	{
+		boolean resultado = false;
+		if ((traerJornadasPorFecha(fechaMesAnterior)) != null)
+		{
+			resultado = true;
+		}
+		return resultado;
 	}
 	
 	public void modificarJornada(Jornada j) throws Exception

--- a/src/test/TestCrearJornadas.java
+++ b/src/test/TestCrearJornadas.java
@@ -29,7 +29,7 @@ public class TestCrearJornadas
 		eAbm.agregarEmpleado("Irione", "Ara", 12345678, Funciones.traerFecha("01/02/2008"), "ara@example.com", cat , tur, gru);*/
 			
 			JornadaABM jAbm = new JornadaABM();
-			jAbm.generarJornadasMes(6, 2015);
+			jAbm.generarJornadasMes();
 			//EmpleadoABM eAbm = new EmpleadoABM();
 			//Empleado emp = eAbm.traerEmpleado(1);
 			//System.out.println(emp);

--- a/src/test/TestCrearJornadas.java
+++ b/src/test/TestCrearJornadas.java
@@ -1,5 +1,8 @@
 package test;
 
+import java.util.GregorianCalendar;
+import datos.Jornada;
+import java.util.List;
 import datos.Categoria;
 import datos.Empleado;
 import datos.GrupoTrabajo;
@@ -30,6 +33,14 @@ public class TestCrearJornadas
 			
 			JornadaABM jAbm = new JornadaABM();
 			jAbm.generarJornadasMes();
+//			GregorianCalendar fechaJornadaEvaluar = new GregorianCalendar(2015, 5, 1);
+//			List <Jornada> jorn = jAbm.traerJornadasPorFecha(fechaJornadaEvaluar);
+//			System.out.println(Funciones.traerMes(fechaJornadaEvaluar));
+//			
+//			for (Jornada j : jorn)
+//			{
+//				System.out.println(j);
+//			}
 			//EmpleadoABM eAbm = new EmpleadoABM();
 			//Empleado emp = eAbm.traerEmpleado(1);
 			//System.out.println(emp);


### PR DESCRIPTION
Funciona, se probó con los meses de Junio (como mes 0, sin jornadas previas) y luego se lo continuo como el mes de Julio (leyendo Jornadas anteriores). 

Técnicamente no deberia pinchar en Enero porque está contemplado, pero no hice el test.
Esta preparado por si se incluyen infinidad de grupos nuevos repartidos en los turnos existentes, por otro lado si se crean turnos nuevos, deberia repartir la jornadas sin problema siempre y cuando los empleados se encuentren en grupos de trabajo para cubrir esos turnos (nada de esto esta probado).
